### PR TITLE
Separate footer information into new partial

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,15 +1,4 @@
-<footer class="footer">
-    {{- if .Site.Copyright }}
-    <span>{{ .Site.Copyright | markdownify }}</span>
-    {{- else }}
-    <span>&copy; {{ now.Year }} <a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a></span>
-    {{- end }}
-    <span>
-        Powered by
-        <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &
-        <a href="https://git.io/hugopapermod" rel="noopener" target="_blank">PaperMod</a>
-    </span>
-</footer>
+{{- partial "footer_info.html" . }}
 
 {{- if (not .Site.Params.disableScrollToTop) }}
 <a href="#top" aria-label="go to top" title="Go to Top (Alt + G)">

--- a/layouts/partials/footer_info.html
+++ b/layouts/partials/footer_info.html
@@ -1,0 +1,13 @@
+<footer class="footer">
+    {{- if .Site.Copyright }}
+    <span id="copyright">{{ default .Site.Copyright | markdownify }}</span>
+    {{- else }}
+    <span id="copyright">&copy; {{ now.Year }} <a href="{{ "" | absLangURL }}">{{ default .Site.Title (.Param "formalName") }}</a></span>
+    {{- end }}
+    <span id="poweredBy">
+        Powered by
+        <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &
+        <a href="https://git.io/hugopapermod" rel="noopener" target="_blank">PaperMod</a>
+    </span>
+</footer>
+


### PR DESCRIPTION
Back port PR:

Separated the footer info into a new partial -- allows for easier replacing and manipulation. Notably, I wanted to have the copyright holder be different than the site title, so I added a parameter there formalName. It also adds ID tags to the copyright and powered by area so we can style each bit with different CSS. Finally, if you want to just rip everything out, you can do that too by replacing the partial.